### PR TITLE
Update ServiceProviders to work with the new ServiceProviderInterface

### DIFF
--- a/src/Grom/Silex/ImagineServiceProvider.php
+++ b/src/Grom/Silex/ImagineServiceProvider.php
@@ -12,9 +12,9 @@ use Silex\ServiceProviderInterface;
  */
 class ImagineServiceProvider implements ServiceProviderInterface
 {
-    public function boot(Application $app){
-    	
-	}
+    public function boot(Application $app)
+    {	
+    }
     
     public function register(Application $app)
     {

--- a/src/Grom/Silex/ImagineServiceProvider.php
+++ b/src/Grom/Silex/ImagineServiceProvider.php
@@ -12,6 +12,10 @@ use Silex\ServiceProviderInterface;
  */
 class ImagineServiceProvider implements ServiceProviderInterface
 {
+    public function boot(Application $app){
+    	
+	}
+    
     public function register(Application $app)
     {
         if(!isset($app['imagine.factory'])) {

--- a/src/Grom/Silex/SnappyServiceProvider.php
+++ b/src/Grom/Silex/SnappyServiceProvider.php
@@ -14,6 +14,10 @@ use Knp\Snappy\Pdf;
  */
 class SnappyServiceProvider implements ServiceProviderInterface
 {
+    public function boot(Application $app){
+    	
+	}
+    
     public function register(Application $app)
     {
         $app['snappy.image'] = $app->share(function ($app) {

--- a/src/Grom/Silex/SnappyServiceProvider.php
+++ b/src/Grom/Silex/SnappyServiceProvider.php
@@ -14,9 +14,9 @@ use Knp\Snappy\Pdf;
  */
 class SnappyServiceProvider implements ServiceProviderInterface
 {
-    public function boot(Application $app){
-    	
-	}
+    public function boot(Application $app)
+    {
+    }
     
     public function register(Application $app)
     {


### PR DESCRIPTION
A few Days ago, the Silex\ServiceProviderInterface has changed.
This causes some Errors when working with your ServiceProviders.

This Request contains the required changes.
